### PR TITLE
Avoid calling 'int(None)'

### DIFF
--- a/pyvizio/cmd_settings.py
+++ b/pyvizio/cmd_settings.py
@@ -55,6 +55,8 @@ class GetCurrentAudioCommand(GetAudioSettingsCommand):
         items = super().process_response(json_obj)
         for itm in items:
             if itm.c_name.lower() == CNames.Audio.VOLUME:
-                return int(itm.value)
+                if itm.value is not None:
+                    return int(itm.value)
+                return None
 
         return 0


### PR DESCRIPTION
I occasionally get the following error in Home Assistant:

`[pyvizio.vizio] Failed to execute command: int() argument must be a string, a bytes-like object or a number, not 'NoneType'`

I think this will fix it.