### PR TITLE
Send other remote keys

### DIFF
--- a/pyvizio/cli.py
+++ b/pyvizio/cli.py
@@ -157,6 +157,12 @@ def channel(vizio, state, amount):
     _LOGGER.info(txt)
     _LOGGER.info("OK" if result else "ERROR")
 
+@cli.command()
+@click.argument("state", required=False)
+@pass_tv
+def remotekey(vizio, state):
+    _LOGGER.info(state)
+    _LOGGER.info("OK" if vizio.remotekey(KeyCodes.__dict__.get(state)) else "ERROR")
 
 @cli.command()
 @click.argument("state", required=False)

--- a/pyvizio/cli.py
+++ b/pyvizio/cli.py
@@ -162,7 +162,7 @@ def channel(vizio, state, amount):
 @pass_tv
 def remotekey(vizio, state):
     _LOGGER.info(state)
-    _LOGGER.info("OK" if vizio.remotekey(KeyCodes.__dict__.get(state)) else "ERROR")
+    _LOGGER.info("OK" if vizio.remotekey(state) else "ERROR")
 
 @cli.command()
 @click.argument("state", required=False)

--- a/pyvizio/cli.py
+++ b/pyvizio/cli.py
@@ -161,8 +161,9 @@ def channel(vizio, state, amount):
 @click.argument("state", required=False)
 @pass_tv
 def remotekey(vizio, state):
+    result = vizio.remotekey(state)
     _LOGGER.info(state)
-    _LOGGER.info("OK" if vizio.remotekey(state) else "ERROR")
+    _LOGGER.info("OK" if result else "ERROR")
 
 @cli.command()
 @click.argument("state", required=False)

--- a/pyvizio/protocol.py
+++ b/pyvizio/protocol.py
@@ -67,6 +67,15 @@ class KeyCodes(object):
     POW_OFF = (11, 0)
     POW_ON = (11, 1)
     POW_TOGGLE = (11, 2)
+    DP_DOWN = (3, 0)
+    DP_LEFT = (3, 1)
+    DP_RIGHT = (3, 7)
+    DP_UP = (3, 8)
+    DP_ENTER = (3, 2)
+    BACK = (4, 0)
+    INFO = (4, 6)
+    MENU = (4, 8)
+    HOME = (4, 15)
 
     class KeyPressActions(object):
         KEY_DOWN = "KEYDOWN"

--- a/pyvizio/vizio.py
+++ b/pyvizio/vizio.py
@@ -129,8 +129,8 @@ class Vizio(object):
         # HACK: Single call just invoking overlay menu with current input
         return self.__remote_multiple(KeyCodes.INPUT_NEXT, 2)
     
-    def remotekey(self):
-        return self.__remote(KeyCodes)
+    def remotekey(self, state):
+        return self.__remote(KeyCodes.__dict__.get(state))
 
     def input_switch(self, name):
         cur_input = self.get_current_input()

--- a/pyvizio/vizio.py
+++ b/pyvizio/vizio.py
@@ -128,6 +128,9 @@ class Vizio(object):
     def input_next(self):
         # HACK: Single call just invoking overlay menu with current input
         return self.__remote_multiple(KeyCodes.INPUT_NEXT, 2)
+    
+    def remotekey(self):
+        return self.__remote(KeyCodes)
 
     def input_switch(self, name):
         cur_input = self.get_current_input()


### PR DESCRIPTION
Created a new "remotekey" command which sends as a keypress any of the remote keys already defined in Keycodes along with some more I added (for DPAD navigation).  Adding any additional keys (set and code) under protocol - Keycodes would then work with this command.  Maybe this would be helpful for other people?

examples:
pyvizio --ip=ip --auth=auth remotekey VOL_DOWN
pyvizio --ip=ip --auth=auth remotekey DP_UP
pyvizio --ip=ip --auth=auth remotekey DP_DOWN
pyvizio --ip=ip --auth=auth remotekey DP_LEFT
pyvizio --ip=ip --auth=auth remotekey DP_RIGHT
pyvizio --ip=ip --auth=auth remotekey DP_ENTER
pyvizio --ip=ip --auth=auth remotekey BACK
