### PR TITLE
Update HA connection check logic, fix Vizio sync class calls, add comments

### DIFF
--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -269,11 +269,9 @@ class VizioAsync(object):
 
     async def can_connect_with_auth_check(self) -> bool:
         """Asynchronously return whether or not device API can be connected to with valid authorization."""
-        if await self.vol_up(log_api_exception=False):
-            await self.vol_down(log_api_exception=False)
-            return True
-
-        return False
+        return bool(
+            await VizioAsync.get_all_audio_settings(self, log_api_exception=False)
+        )
 
     async def can_connect_no_auth_check(self) -> bool:
         """Asynchronously return whether or not device API can be connected to regardless of authorization."""
@@ -437,8 +435,8 @@ class VizioAsync(object):
 
     async def get_current_volume(self, log_api_exception: bool = True) -> Optional[int]:
         """Asynchronously get device's current volume level."""
-        return await self.get_audio_setting(
-            "volume", log_api_exception=log_api_exception
+        return await VizioAsync.get_audio_setting(
+            self, "volume", log_api_exception=log_api_exception
         )
 
     async def is_muted(self, log_api_exception: bool = True) -> Optional[bool]:
@@ -446,8 +444,8 @@ class VizioAsync(object):
         # If None is returned lower() will fail, if not we can do a simple boolean check
         try:
             return (
-                await self.get_audio_setting(
-                    "mute", log_api_exception=log_api_exception
+                await VizioAsync.get_audio_setting(
+                    self, "mute", log_api_exception=log_api_exception
                 ).lower()
                 == "on"
             )
@@ -630,30 +628,32 @@ class VizioAsync(object):
         self, log_api_exception: bool = True
     ) -> Optional[Dict[str, Union[int, str]]]:
         """Asynchronously get all audio setting names and corresponding values."""
-        return await self.get_all_settings("audio", log_api_exception=log_api_exception)
+        return await VizioAsync.get_all_settings(
+            self, "audio", log_api_exception=log_api_exception
+        )
 
     async def get_all_audio_settings_options(
         self, log_api_exception: bool = True
     ) -> Optional[Dict[str, Union[int, str]]]:
         """Asynchronously get all audio setting names and corresponding options."""
-        return await self.get_all_settings_options(
-            "audio", log_api_exception=log_api_exception
+        return await VizioAsync.get_all_settings_options(
+            self, "audio", log_api_exception=log_api_exception
         )
 
     async def get_audio_setting(
         self, setting_name: str, log_api_exception: bool = True
     ) -> Optional[Union[int, str]]:
         """Asynchronously get current value of named audio setting."""
-        return await self.get_setting(
-            "audio", setting_name, log_api_exception=log_api_exception
+        return await VizioAsync.get_setting(
+            self, "audio", setting_name, log_api_exception=log_api_exception
         )
 
     async def get_audio_setting_options(
         self, setting_name: str, log_api_exception: bool = True
     ) -> Optional[Union[int, str]]:
         """Asynchronously get options of named audio setting."""
-        return await self.get_setting_options(
-            "audio", setting_name, log_api_exception=log_api_exception
+        return await VizioAsync.get_setting_options(
+            self, "audio", setting_name, log_api_exception=log_api_exception
         )
 
     async def set_audio_setting(
@@ -663,8 +663,8 @@ class VizioAsync(object):
         log_api_exception: bool = True,
     ) -> Optional[bool]:
         """Asynchronously set new value for named audio setting."""
-        return await self.set_setting(
-            "audio", setting_name, new_value, log_api_exception=log_api_exception
+        return await VizioAsync.set_setting(
+            self, "audio", setting_name, new_value, log_api_exception=log_api_exception
         )
 
     @staticmethod

--- a/pyvizio/api/apps.py
+++ b/pyvizio/api/apps.py
@@ -45,6 +45,7 @@ def find_app_name(config_to_check: AppConfig, app_list: List[Dict[str, Any]]) ->
     if not config_to_check:
         return NO_APP_RUNNING
 
+    # Attempt to find an exact match from known apps list
     for app_def in app_list:
         if isinstance(app_def["config"], list):
             for config in app_def["config"]:
@@ -60,6 +61,8 @@ def find_app_name(config_to_check: AppConfig, app_list: List[Dict[str, Any]]) ->
         ):
             return app_def["name"]
 
+    # If exact match couldn't be find, swap in equivalent name spaces
+    # and attempt to find a match
     if config_to_check.NAME_SPACE in EQUIVALENT_NAME_SPACES:
         for app_def in app_list:
             if isinstance(app_def["config"], list):
@@ -76,9 +79,11 @@ def find_app_name(config_to_check: AppConfig, app_list: List[Dict[str, Any]]) ->
             ):
                 return app_def["name"]
 
+    # So far only the SmartCast home screen appears to use the NAME_SPACE of 0
     if config_to_check.NAME_SPACE == 0:
         return APP_CAST
 
+    # If no match, app is unknown
     return UNKNOWN_APP
 
 

--- a/pyvizio/version.py
+++ b/pyvizio/version.py
@@ -1,3 +1,3 @@
 """pyvizio version."""
 
-__version__ = "0.1.47"
+__version__ = "0.1.48"


### PR DESCRIPTION
- Old logic used to mess with the volume. I found an API call I can make to check the connection is valid, including access token, without having to have end user impact.
- I noticed that some calls in the Vizio synchronous class fail. This is because it is a subclass of the Vizio async class (to maintain backwards compatibility) that calls the super class function for every function. When I call a super class function that refers to another function which is defined in both the super and subclass, it runs the subclass function instead of the superclass function. The changes I made explicitly force VizioAsync functions to call other VizioAsync functions when the same function is overridden in the child class to avoid this issue.
- Added some comments to the logic for finding an app name