### PR TITLE
Add version requirement for pip installation.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[options]
+python_requires = >= 3.7
+
 [flake8]
 exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
 doctests = True


### PR DESCRIPTION
In response to https://github.com/vkorn/pyvizio/issues/87

Users see error at runtime when using a lower python version than required.  This change gives them a clear indication of required python version at the time of pip install.

```
$ python -V
Python 3.6.5
$ pip install -e .
...
pyvizio requires Python '>= 3.7' but the running Python is 3.6.5

```
```
$ python -V
Python 3.7.0
$ pip install -e .
...
Successfully installed ... pyvizio ...
```