### PR TITLE
fix: multiple CLI and API bug fixes

### DIFF
--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -1169,8 +1169,8 @@ class Vizio(VizioAsync):
             setting_name, new_value, log_api_exception=log_api_exception
         )
 
-    @async_to_sync
     @staticmethod
+    @async_to_sync
     async def get_apps_list(
         country: str = "all",
         apps_list: List[Dict[str, Union[str, List[Union[str, Dict[str, Any]]]]]] = None,

--- a/pyvizio/cli.py
+++ b/pyvizio/cli.py
@@ -403,8 +403,8 @@ async def key_press(vizio: VizioAsync, key: str) -> None:
 
 @cli.command()
 @pass_vizio
-async def get_remote_keys_list(vizio: VizioAsync) -> None:
-    table = tabulate(vizio.get_remote_keys_list(), headers=["App Name"])
+def get_remote_keys_list(vizio: VizioAsync) -> None:
+    table = tabulate(vizio.get_remote_keys_list(), headers=["Key Name"])
     _LOGGER.info("\n%s", table)
 
 

--- a/pyvizio/cli.py
+++ b/pyvizio/cli.py
@@ -480,7 +480,7 @@ async def get_setting_options(
         _LOGGER.error("Couldn't get options for '%s' setting", setting_name)
 
 
-@cli.command()
+@cli.command(context_settings={"allow_interspersed_args": False})
 @click.argument("setting_type", required=True, type=click.STRING)
 @click.argument("setting_name", required=True, type=click.STRING)
 @click.argument("new_value", required=True, type=click.STRING)
@@ -592,7 +592,7 @@ async def get_audio_setting_options(vizio: VizioAsync, setting_name: str) -> Non
         _LOGGER.error("Couldn't get options for '%s' setting", setting_name)
 
 
-@cli.command()
+@cli.command(context_settings={"allow_interspersed_args": False})
 @click.argument("setting_name", required=True, type=click.STRING)
 @click.argument("new_value", required=True, type=click.STRING)
 @async_to_sync


### PR DESCRIPTION
## Summary

This PR bundles several small bug fixes:

- **#173**: Allow negative numbers as CLI arguments for `audio_setting` and `setting` commands
- **#131/#132**: Fix `get_remote_keys_list` CLI command RuntimeWarning (coroutine never awaited)
- **#167**: Fix `Vizio.get_apps_list()` AttributeError when called on instance

## Changes

### CLI negative numbers (#173)
Add `context_settings={"allow_interspersed_args": False}` to `audio_setting` and `setting` commands so that negative values like `-2` are parsed as positional arguments rather than option flags.

### get_remote_keys_list RuntimeWarning (#131, #132)
Remove `async` keyword from CLI function that doesn't need it - the underlying method is synchronous. Also fixed table header from "App Name" to "Key Name".

### Vizio.get_apps_list AttributeError (#167)
Swap `@async_to_sync` and `@staticmethod` decorator order. When `@async_to_sync` wrapped `@staticmethod`, calling the method on an instance passed `self` as the first argument (becoming `country`), causing `'Vizio' object has no attribute 'lower'`.

## Test plan

- [ ] `pyvizio audio-setting bass -2` no longer errors with "No such option: -2"
- [ ] `pyvizio get-remote-keys-list` no longer shows RuntimeWarning
- [ ] `Vizio.get_apps_list()` works when called on an instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)