### PR TITLE
fix: prevent Windows 'Event loop is closed' RuntimeError

### DIFF
--- a/pyvizio/helpers.py
+++ b/pyvizio/helpers.py
@@ -1,8 +1,15 @@
 """pyvizio helper functions."""
 
 import asyncio
+import sys
 from functools import wraps
 from typing import Any, Dict, List, Optional
+
+# Fix for Windows ProactorEventLoop cleanup issue causing
+# "RuntimeError: Event loop is closed" on exit.
+# See: https://github.com/aio-libs/aiohttp/issues/4324
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
 def async_to_sync(f):


### PR DESCRIPTION
## Summary

Fix the `RuntimeError: Event loop is closed` error that occurs on Windows after CLI commands complete.

## Problem

On Windows with Python 3.8+, `asyncio.run()` uses `ProactorEventLoop` by default. When the event loop closes, aiohttp's HTTP transports attempt cleanup but the loop is already gone, causing:

```
RuntimeError: Event loop is closed
```

This error appears after commands succeed (e.g., pairing shows the token, then the error prints).

## Solution

Set `WindowsSelectorEventLoopPolicy` on Windows at module import time. This uses `SelectorEventLoop` instead of `ProactorEventLoop`, which handles cleanup properly.

```python
if sys.platform == "win32":
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```

This is a well-known fix for aiohttp on Windows. See: https://github.com/aio-libs/aiohttp/issues/4324

Fixes #115

## Test plan

- [ ] Run any CLI command on Windows (e.g., `pyvizio pair`) and verify no RuntimeError on exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)