### PR TITLE
fix: XList settings commands and set_setting with missing setting

### DIFF
--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -663,7 +663,7 @@ class VizioAsync:
             log_api_exception=log_api_exception,
         )
 
-        if not setting_item:
+        if not setting_item or not hasattr(setting_item, "id"):
             _LOGGER.error(
                 "Couldn't detect setting for %s of setting type %s",
                 setting_name,

--- a/pyvizio/api/settings.py
+++ b/pyvizio/api/settings.py
@@ -138,10 +138,13 @@ class GetAllSettingsOptionsXListCommand(ItemInfoCommandBase):
         items = [
             Item(item)
             for item in dict_get_case_insensitive(json_obj, ResponseKey.ITEMS, [])
-            if item.type.lower() == TYPE_X_LIST
         ]
 
-        return {item.c_name: item.choices for item in items}
+        return {
+            item.c_name: item.choices
+            for item in items
+            if item.type and item.type.lower() == TYPE_X_LIST
+        }
 
 
 class GetSettingOptionsXListCommand(GetAllSettingsOptionsXListCommand):


### PR DESCRIPTION
## Summary
- Fix `GetAllSettingsOptionsXListCommand.process_response` filtering on raw dict `.type` before `Item()` conversion, causing silent `AttributeError` — XList settings always returned `None`
- Fix `VizioAsync.set_setting` accessing `.id` on `DefaultReturnItem` when setting name not found, causing `AttributeError` — now returns `None` gracefully

## Details

**Bug 1: XList commands always return None**

In `settings.py`, the list comprehension filter `if item.type.lower() == TYPE_X_LIST` ran on the raw dict *before* it was wrapped in `Item(item)`. Raw dicts don't have a `.type` attribute, so every call raised `AttributeError`, which was silently caught by the broad `except` in `async_invoke_api`.

Fix: Convert all items to `Item` objects first, then filter.

**Bug 2: set_setting crashes on missing setting**

`GetSettingCommand` uses `default_return=0`, so when a setting name isn't found, it returns `DefaultReturnItem(0)`. This object is truthy (passes `if not setting_item`), but lacks `.id`. The subsequent `ChangeSettingCommand(... setting_item.id ...)` then raises `AttributeError`.

Fix: Add `hasattr(setting_item, "id")` guard.

## Test plan
- [x] Verified XList fix returns correct filtered results
- [x] Verified set_setting guard catches DefaultReturnItem

🤖 Generated with [Claude Code](https://claude.com/claude-code)