### PR TITLE
refactor: simplify invoke_api and remove trivial commands

### DIFF
--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -29,17 +29,10 @@ from pyvizio.api.input import (
     InputItem,
 )
 from pyvizio.api.item import (
-    GetAltESNCommand,
-    GetAltSerialNumberCommand,
-    GetAltVersionCommand,
-    GetBatteryLevelCommand,
-    GetCurrentChargingStatusCommand,
-    GetCurrentPowerStateCommand,
+    AltItemInfoCommandBase,
     GetDeviceInfoCommand,
-    GetESNCommand,
     GetModelNameCommand,
-    GetSerialNumberCommand,
-    GetVersionCommand,
+    ItemInfoCommandBase,
 )
 from pyvizio.api.pair import (
     BeginPairCommand,
@@ -304,9 +297,11 @@ class VizioAsync:
     async def get_esn(self, log_api_exception: bool = True) -> str | None:
         """Asynchronously get device's ESN (electronic serial number?)."""
         item = await self.__invoke_api_may_need_auth(
-            GetESNCommand(self.device_type), log_api_exception=log_api_exception
+            ItemInfoCommandBase(self.device_type, "ESN"),
+            log_api_exception=log_api_exception,
         ) or await self.__invoke_api_may_need_auth(
-            GetAltESNCommand(self.device_type), log_api_exception=log_api_exception
+            AltItemInfoCommandBase(self.device_type, "_ALT_ESN", "ESN"),
+            log_api_exception=log_api_exception,
         )
 
         if item and item.value:
@@ -317,10 +312,12 @@ class VizioAsync:
     async def get_serial_number(self, log_api_exception: bool = True) -> str | None:
         """Asynchronously get device's serial number."""
         item = await self.__invoke_api(
-            GetSerialNumberCommand(self.device_type),
+            ItemInfoCommandBase(self.device_type, "SERIAL_NUMBER"),
             log_api_exception=log_api_exception,
         ) or await self.__invoke_api(
-            GetAltSerialNumberCommand(self.device_type),
+            AltItemInfoCommandBase(
+                self.device_type, "_ALT_SERIAL_NUMBER", "SERIAL_NUMBER"
+            ),
             log_api_exception=log_api_exception,
         )
 
@@ -332,9 +329,11 @@ class VizioAsync:
     async def get_version(self, log_api_exception: bool = True) -> str | None:
         """Asynchronously get SmartCast software version on device."""
         item = await self.__invoke_api(
-            GetVersionCommand(self.device_type), log_api_exception=log_api_exception
+            ItemInfoCommandBase(self.device_type, "VERSION"),
+            log_api_exception=log_api_exception,
         ) or await self.__invoke_api(
-            GetAltVersionCommand(self.device_type), log_api_exception=log_api_exception
+            AltItemInfoCommandBase(self.device_type, "_ALT_VERSION", "VERSION"),
+            log_api_exception=log_api_exception,
         )
 
         if item and item.value:
@@ -425,7 +424,7 @@ class VizioAsync:
     async def get_power_state(self, log_api_exception: bool = True) -> bool | None:
         """Asynchronously get device's current power state."""
         item = await self.__invoke_api_may_need_auth(
-            GetCurrentPowerStateCommand(self.device_type),
+            ItemInfoCommandBase(self.device_type, "POWER_MODE", 0),
             log_api_exception=log_api_exception,
         )
 
@@ -437,7 +436,7 @@ class VizioAsync:
     async def get_charging_status(self, log_api_exception: bool = True) -> int | None:
         """Asynchronously get device's current charging state."""
         item = await self.__invoke_api_may_need_auth(
-            GetCurrentChargingStatusCommand(self.device_type),
+            ItemInfoCommandBase(self.device_type, "CHARGING_STATUS", 0),
             log_api_exception=log_api_exception,
         )
 
@@ -449,7 +448,7 @@ class VizioAsync:
     async def get_battery_level(self, log_api_exception: bool = True) -> int | None:
         """Asynchronously get device's current battery level (will be 0 if charging)."""
         item = await self.__invoke_api_may_need_auth(
-            GetBatteryLevelCommand(self.device_type),
+            ItemInfoCommandBase(self.device_type, "BATTERY_LEVEL", 0),
             log_api_exception=log_api_exception,
         )
         if item:

--- a/pyvizio/api/_protocol.py
+++ b/pyvizio/api/_protocol.py
@@ -226,6 +226,33 @@ async def async_validate_response(web_response: ClientResponse) -> dict[str, Any
     return data
 
 
+async def _do_request(
+    active_session: ClientSession,
+    method: str,
+    url: str,
+    headers: dict[str, Any],
+    data: str,
+    timeout: ClientTimeout,
+) -> ClientResponse:
+    """Execute a single GET or PUT request on the given session."""
+    if method == "get":
+        _LOGGER.debug(
+            "Using Request: %s", {"method": "get", "url": url, "headers": headers}
+        )
+        return await active_session.get(
+            url=url, headers=headers, ssl=False, timeout=timeout
+        )
+
+    headers["Content-Type"] = "application/json"
+    _LOGGER.debug(
+        "Using Request: %s",
+        {"method": "put", "url": url, "headers": headers, "data": json.loads(data)},
+    )
+    return await active_session.put(
+        url=url, data=data, headers=headers, ssl=False, timeout=timeout
+    )
+
+
 async def async_invoke_api(
     ip: str,
     command: CommandBase,
@@ -238,76 +265,25 @@ async def async_invoke_api(
     """Call API endpoints with appropriate request bodies and headers."""
     if headers is None:
         headers = {}
-    method = command.get_method()
     url = f"https://{ip}{command.get_url()}"
     data = json.dumps(command.to_dict())
+    method = command.get_method().lower()
+    timeout = (
+        ClientTimeout(total=custom_timeout)
+        if custom_timeout
+        else AIOHTTP_DEFAULT_TIMEOUT
+    )
     _LOGGER.debug("Using Command: %s", command)
-
-    if not custom_timeout:
-        timeout = AIOHTTP_DEFAULT_TIMEOUT
-    else:
-        timeout = ClientTimeout(total=custom_timeout)
-
-    if not headers:
-        headers = {}
 
     try:
         if session:
-            if "get" == method.lower():
-                _LOGGER.debug(
-                    "Using Request: %s",
-                    {"method": "get", "url": url, "headers": headers},
-                )
-                response = await session.get(
-                    url=url, headers=headers, ssl=False, timeout=timeout
-                )
-            else:
-                timeout = AIOHTTP_DEFAULT_TIMEOUT
-                headers["Content-Type"] = "application/json"
-                _LOGGER.debug(
-                    "Using Request: %s",
-                    {
-                        "method": "put",
-                        "url": url,
-                        "headers": headers,
-                        "data": json.loads(str(data)),
-                    },
-                )
-                response = await session.put(
-                    url=url, data=str(data), headers=headers, ssl=False, timeout=timeout
-                )
-
+            response = await _do_request(session, method, url, headers, data, timeout)
             json_obj = await async_validate_response(response)
         else:
             async with ClientSession() as local_session:
-                if "get" == method.lower():
-                    _LOGGER.debug(
-                        "Using Request: %s",
-                        {"method": "get", "url": url, "headers": headers},
-                    )
-                    response = await local_session.get(
-                        url=url, headers=headers, ssl=False, timeout=timeout
-                    )
-                else:
-                    timeout = AIOHTTP_DEFAULT_TIMEOUT
-                    headers["Content-Type"] = "application/json"
-                    _LOGGER.debug(
-                        "Using Request: %s",
-                        {
-                            "method": "put",
-                            "url": url,
-                            "headers": headers,
-                            "data": json.loads(str(data)),
-                        },
-                    )
-                    response = await local_session.put(
-                        url=url,
-                        data=str(data),
-                        headers=headers,
-                        ssl=False,
-                        timeout=timeout,
-                    )
-
+                response = await _do_request(
+                    local_session, method, url, headers, data, timeout
+                )
                 json_obj = await async_validate_response(response)
 
         return command.process_response(json_obj)

--- a/pyvizio/api/item.py
+++ b/pyvizio/api/item.py
@@ -156,54 +156,6 @@ class ItemCommandBase(CommandBase):
         self.REQUEST = ACTION_MODIFY.upper()
 
 
-class GetCurrentPowerStateCommand(ItemInfoCommandBase):
-    """Command to get current power state of device."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get current power state of device."""
-        super().__init__(device_type, "POWER_MODE", 0)
-
-
-class GetCurrentChargingStatusCommand(ItemInfoCommandBase):
-    """Command to get current charging status of device."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get current charging status of device."""
-        super().__init__(device_type, "CHARGING_STATUS", 0)
-
-
-class GetBatteryLevelCommand(ItemInfoCommandBase):
-    """Command to get current battery level (will be 0 if charging) of device."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get current battery level (will be 0 if charging) of device."""
-        super().__init__(device_type, "BATTERY_LEVEL", 0)
-
-
-class GetESNCommand(ItemInfoCommandBase):
-    """Command to get device ESN (electronic serial number?)."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get device ESN (electronic serial number?)."""
-        super().__init__(device_type, "ESN")
-
-
-class GetSerialNumberCommand(ItemInfoCommandBase):
-    """Command to get device serial number."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get device serial number."""
-        super().__init__(device_type, "SERIAL_NUMBER")
-
-
-class GetVersionCommand(ItemInfoCommandBase):
-    """Command to get SmartCast software version."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get SmartCast software version."""
-        super().__init__(device_type, "VERSION")
-
-
 class AltItemInfoCommandBase(ItemInfoCommandBase):
     """Command to get individual item setting."""
 
@@ -218,27 +170,3 @@ class AltItemInfoCommandBase(ItemInfoCommandBase):
         super(ItemInfoCommandBase, self).__init__(ENDPOINT[device_type][endpoint_name])
         self.item_name = item_name.upper()
         self.default_return = default_return
-
-
-class GetAltESNCommand(AltItemInfoCommandBase):
-    """Command to get device ESN (electronic serial number?)."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get device ESN (electronic serial number?)."""
-        super().__init__(device_type, "_ALT_ESN", "ESN")
-
-
-class GetAltSerialNumberCommand(AltItemInfoCommandBase):
-    """Command to get device serial number."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get device serial number."""
-        super().__init__(device_type, "_ALT_SERIAL_NUMBER", "SERIAL_NUMBER")
-
-
-class GetAltVersionCommand(AltItemInfoCommandBase):
-    """Command to get SmartCast software version."""
-
-    def __init__(self, device_type: str) -> None:
-        """Initialize command to get SmartCast software version."""
-        super().__init__(device_type, "_ALT_VERSION", "VERSION")


### PR DESCRIPTION
## Summary
- Extract `_do_request()` helper in `_protocol.py` to deduplicate GET/PUT request logic across session/no-session code paths
- Fix bug where PUT requests with a provided session ignored `custom_timeout` (was always using `AIOHTTP_DEFAULT_TIMEOUT`)
- Remove 9 trivial `ItemInfoCommandBase`/`AltItemInfoCommandBase` subclasses that only forwarded arguments
- Replace with direct instantiation in `__init__.py`

## Removed classes
`GetCurrentPowerStateCommand`, `GetCurrentChargingStatusCommand`, `GetBatteryLevelCommand`, `GetESNCommand`, `GetSerialNumberCommand`, `GetVersionCommand`, `GetAltESNCommand`, `GetAltSerialNumberCommand`, `GetAltVersionCommand`

## Test plan
- [x] All 196 tests pass
- [x] `ruff check` and `ruff format` pass
- [x] Import verification: `from pyvizio import VizioAsync, Vizio, guess_device_type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)