### PR TITLE
refactor: consolidate device configuration into DeviceConfig dataclass

### DIFF
--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -59,10 +59,11 @@ from pyvizio.const import (
     DEFAULT_DEVICE_CLASS,
     DEFAULT_PORTS,
     DEFAULT_TIMEOUT,
-    DEVICE_CLASS_CRAVE360,
+    DEVICE_CLASS_CRAVE360 as DEVICE_CLASS_CRAVE360,
     DEVICE_CLASS_SPEAKER,
     DEVICE_CLASS_TV,
-    MAX_VOLUME,
+    DEVICE_CONFIGS,
+    MAX_VOLUME as MAX_VOLUME,
 )
 from pyvizio.discovery.ssdp import SSDPDevice, discover as discover_ssdp
 from pyvizio.discovery.zeroconf import ZeroconfDevice, discover as discover_zc
@@ -88,15 +89,12 @@ class VizioAsync:
     ) -> None:
         """Initialize asynchronous class to interact with Vizio SmartCast devices."""
         self.device_type = device_type.lower()
-        if (
-            self.device_type != DEVICE_CLASS_TV
-            and self.device_type != DEVICE_CLASS_SPEAKER
-            and self.device_type != DEVICE_CLASS_CRAVE360
-        ):
+        if self.device_type not in DEVICE_CONFIGS:
             raise Exception(
-                f"Invalid device type specified. Use either '{DEVICE_CLASS_TV}' or "
-                f"'{DEVICE_CLASS_SPEAKER}' or '{DEVICE_CLASS_CRAVE360}''"
+                f"Invalid device type specified. Use one of: "
+                f"{', '.join(repr(k) for k in DEVICE_CONFIGS)}"
             )
+        self._device_config = DEVICE_CONFIGS[self.device_type]
 
         self._auth_token = auth_token
         self.ip = ip
@@ -157,15 +155,15 @@ class VizioAsync:
     ) -> Any:
         """Asynchronously call SmartCast API command with or without auth token depending on device type."""
         if not self._auth_token:
-            if (
-                self.device_type == DEVICE_CLASS_SPEAKER
-                or self.device_type == DEVICE_CLASS_CRAVE360
-            ):
+            if not self._device_config.requires_auth:
                 return await self.__invoke_api(cmd, log_api_exception=log_api_exception)
             else:
+                no_auth_types = [
+                    k for k, v in DEVICE_CONFIGS.items() if not v.requires_auth
+                ]
                 raise Exception(
-                    f"Empty auth token. To target a speaker and bypass auth "
-                    f"requirements, pass '{DEVICE_CLASS_SPEAKER}' as device_type"
+                    f"Empty auth token. Device types that don't require auth: "
+                    f"{', '.join(repr(t) for t in no_auth_types)}"
                 )
         return await self.__invoke_api_auth(cmd, log_api_exception=log_api_exception)
 
@@ -507,7 +505,7 @@ class VizioAsync:
 
     def get_max_volume(self) -> int:
         """Get device's max volume based on device type."""
-        return MAX_VOLUME[self.device_type]
+        return self._device_config.max_volume
 
     async def ch_up(self, num: int = 1, log_api_exception: bool = True) -> bool | None:
         """Asynchronously channel up by number of steps."""

--- a/pyvizio/api/_protocol.py
+++ b/pyvizio/api/_protocol.py
@@ -10,7 +10,7 @@ from aiohttp import ClientResponse, ClientSession, ClientTimeout
 from aiohttp.client import DEFAULT_TIMEOUT as AIOHTTP_DEFAULT_TIMEOUT
 
 from pyvizio.api.base import CommandBase
-from pyvizio.const import DEVICE_CLASS_CRAVE360, DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
+from pyvizio.const import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV, DEVICE_CONFIGS
 from pyvizio.helpers import dict_get_case_insensitive
 
 _LOGGER = getLogger(__name__)
@@ -31,66 +31,8 @@ TYPE_VALUE = "t_value_v1"
 TYPE_MENU = "t_menu_v1"
 TYPE_X_LIST = "t_list_x_v1"
 
-ENDPOINT = {
-    DEVICE_CLASS_TV: {
-        "BEGIN_PAIR": "/pairing/start",
-        "FINISH_PAIR": "/pairing/pair",
-        "CANCEL_PAIR": "/pairing/cancel",
-        "INPUTS": "/menu_native/dynamic/tv_settings/devices/name_input",
-        "CURRENT_INPUT": "/menu_native/dynamic/tv_settings/devices/current_input",
-        "ESN": "/menu_native/dynamic/tv_settings/system/system_information/uli_information/esn",
-        "SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/system/system_information/tv_information/serial_number",
-        "VERSION": "/menu_native/dynamic/tv_settings/system/system_information/tv_information/version",
-        "_ALT_ESN": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/uli_information/esn",
-        "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/serial_number",
-        "_ALT_VERSION": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/version",
-        "DEVICE_INFO": "/state/device/deviceinfo",
-        "POWER_MODE": "/state/device/power_mode",
-        "KEY_PRESS": "/key_command/",
-        "SETTINGS": "/menu_native/dynamic/tv_settings",
-        "SETTINGS_OPTIONS": "/menu_native/static/tv_settings",
-        "CURRENT_APP": "/app/current",
-        "LAUNCH_APP": "/app/launch",
-    },
-    DEVICE_CLASS_SPEAKER: {
-        "BEGIN_PAIR": "/pairing/start",
-        "FINISH_PAIR": "/pairing/pair",
-        "CANCEL_PAIR": "/pairing/cancel",
-        "INPUTS": "/menu_native/dynamic/audio_settings/input",
-        "CURRENT_INPUT": "/menu_native/dynamic/audio_settings/input/current_input",
-        "ESN": "/menu_native/dynamic/audio_settings/system/system_information/uli_information/esn",
-        "SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/serial_number",
-        "VERSION": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/version",
-        "_ALT_ESN": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/uli_information/esn",
-        "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/serial_number",
-        "_ALT_VERSION": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/version",
-        "DEVICE_INFO": "/state/device/deviceinfo",
-        "POWER_MODE": "/state/device/power_mode",
-        "KEY_PRESS": "/key_command/",
-        "SETTINGS": "/menu_native/dynamic/audio_settings",
-        "SETTINGS_OPTIONS": "/menu_native/static/audio_settings",
-    },
-    DEVICE_CLASS_CRAVE360: {
-        "BEGIN_PAIR": "/pairing/start",
-        "FINISH_PAIR": "/pairing/pair",
-        "CANCEL_PAIR": "/pairing/cancel",
-        "INPUTS": "/menu_native/dynamic/audio_settings/input",
-        "CURRENT_INPUT": "/menu_native/dynamic/audio_settings/input/current_input",
-        "ESN": "/menu_native/dynamic/audio_settings/system/system_information/uli_information/esn",
-        "SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/serial_number",
-        "VERSION": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/version",
-        "_ALT_ESN": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/uli_information/esn",
-        "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/serial_number",
-        "_ALT_VERSION": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/version",
-        "DEVICE_INFO": "/state/device/deviceinfo",
-        "POWER_MODE": "/state/device/power_mode",
-        "KEY_PRESS": "/key_command/",
-        "SETTINGS": "/menu_native/dynamic/audio_settings",
-        "SETTINGS_OPTIONS": "/menu_native/static/audio_settings",
-        "CHARGING_STATUS": "/state/device/charging_status",
-        "BATTERY_LEVEL": "/state/device/battery_level",
-    },
-}
+# Derived from DEVICE_CONFIGS — single source of truth in const.py
+ENDPOINT = {k: v.endpoints for k, v in DEVICE_CONFIGS.items()}
 
 ITEM_CNAME = {
     "CURRENT_INPUT": "current_input",
@@ -105,65 +47,8 @@ ITEM_CNAME = {
 
 KEY_ACTION = {"DOWN": "KEYDOWN", "UP": "KEYUP", "PRESS": "KEYPRESS"}
 
-KEY_CODE = {
-    DEVICE_CLASS_TV: {
-        "SEEK_FWD": (2, 0),
-        "SEEK_BACK": (2, 1),
-        "PAUSE": (2, 2),
-        "PLAY": (2, 3),
-        "DOWN": (3, 0),
-        "LEFT": (3, 1),
-        "OK": (3, 2),
-        "UP": (3, 8),
-        "LEFT2": (3, 4),
-        "RIGHT": (3, 7),
-        "BACK": (4, 0),
-        "SMARTCAST": (4, 3),
-        "CC_TOGGLE": (4, 4),
-        "INFO": (4, 6),
-        "MENU": (4, 8),
-        "HOME": (4, 15),
-        "VOL_DOWN": (5, 0),
-        "VOL_UP": (5, 1),
-        "MUTE_OFF": (5, 2),
-        "MUTE_ON": (5, 3),
-        "MUTE_TOGGLE": (5, 4),
-        "PIC_MODE": (6, 0),
-        "PIC_SIZE": (6, 2),
-        "INPUT_NEXT": (7, 1),
-        "CH_DOWN": (8, 0),
-        "CH_UP": (8, 1),
-        "CH_PREV": (8, 2),
-        "EXIT": (9, 0),
-        "POW_OFF": (11, 0),
-        "POW_ON": (11, 1),
-        "POW_TOGGLE": (11, 2),
-    },
-    DEVICE_CLASS_SPEAKER: {
-        "PAUSE": (2, 2),
-        "PLAY": (2, 3),
-        "VOL_DOWN": (5, 0),
-        "VOL_UP": (5, 1),
-        "MUTE_OFF": (5, 2),
-        "MUTE_ON": (5, 3),
-        "MUTE_TOGGLE": (5, 4),
-        "POW_OFF": (11, 0),
-        "POW_ON": (11, 1),
-        "POW_TOGGLE": (11, 2),
-    },
-    DEVICE_CLASS_CRAVE360: {
-        "PAUSE": (2, 2),
-        "PLAY": (2, 3),
-        "VOL_DOWN": (5, 0),
-        "VOL_UP": (5, 1),
-        "MUTE_OFF": (5, 2),
-        "MUTE_ON": (5, 3),
-        "MUTE_TOGGLE": (5, 4),
-        "POW_OFF": (11, 0),
-        "POW_ON": (11, 1),
-        "POW_TOGGLE": (11, 2),
-    },
-}
+# Derived from DEVICE_CONFIGS — single source of truth in const.py
+KEY_CODE = {k: v.key_codes for k, v in DEVICE_CONFIGS.items()}
 
 PATH_MODEL = {
     DEVICE_CLASS_SPEAKER: [["name"]],

--- a/pyvizio/const.py
+++ b/pyvizio/const.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from importlib import resources
 import json
-from typing import Any
 
 DEVICE_CLASS_SPEAKER = "speaker"
 DEVICE_CLASS_TV = "tv"
@@ -48,10 +48,155 @@ APP_HOME = {
 }
 
 
-def _load_apps() -> list[dict[str, Any]]:
+def _load_apps() -> list[dict]:
     """Load apps list from bundled JSON data."""
     ref = resources.files("pyvizio.data").joinpath("apps.json")
     return json.loads(ref.read_text(encoding="utf-8"))
 
 
-APPS: list[dict[str, Any]] = _load_apps()
+APPS: list[dict] = _load_apps()
+
+
+@dataclass(frozen=True)
+class DeviceConfig:
+    """Configuration for a specific Vizio device class."""
+
+    device_class: str
+    requires_auth: bool
+    max_volume: int
+    endpoints: dict[str, str] = field(repr=False)
+    key_codes: dict[str, tuple[int, int]] = field(repr=False)
+
+
+DEVICE_CONFIGS: dict[str, DeviceConfig] = {
+    DEVICE_CLASS_TV: DeviceConfig(
+        device_class=DEVICE_CLASS_TV,
+        requires_auth=True,
+        max_volume=100,
+        endpoints={
+            "BEGIN_PAIR": "/pairing/start",
+            "FINISH_PAIR": "/pairing/pair",
+            "CANCEL_PAIR": "/pairing/cancel",
+            "INPUTS": "/menu_native/dynamic/tv_settings/devices/name_input",
+            "CURRENT_INPUT": "/menu_native/dynamic/tv_settings/devices/current_input",
+            "ESN": "/menu_native/dynamic/tv_settings/system/system_information/uli_information/esn",
+            "SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/system/system_information/tv_information/serial_number",
+            "VERSION": "/menu_native/dynamic/tv_settings/system/system_information/tv_information/version",
+            "_ALT_ESN": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/uli_information/esn",
+            "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/serial_number",
+            "_ALT_VERSION": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/version",
+            "DEVICE_INFO": "/state/device/deviceinfo",
+            "POWER_MODE": "/state/device/power_mode",
+            "KEY_PRESS": "/key_command/",
+            "SETTINGS": "/menu_native/dynamic/tv_settings",
+            "SETTINGS_OPTIONS": "/menu_native/static/tv_settings",
+            "CURRENT_APP": "/app/current",
+            "LAUNCH_APP": "/app/launch",
+        },
+        key_codes={
+            "SEEK_FWD": (2, 0),
+            "SEEK_BACK": (2, 1),
+            "PAUSE": (2, 2),
+            "PLAY": (2, 3),
+            "DOWN": (3, 0),
+            "LEFT": (3, 1),
+            "OK": (3, 2),
+            "UP": (3, 8),
+            "LEFT2": (3, 4),
+            "RIGHT": (3, 7),
+            "BACK": (4, 0),
+            "SMARTCAST": (4, 3),
+            "CC_TOGGLE": (4, 4),
+            "INFO": (4, 6),
+            "MENU": (4, 8),
+            "HOME": (4, 15),
+            "VOL_DOWN": (5, 0),
+            "VOL_UP": (5, 1),
+            "MUTE_OFF": (5, 2),
+            "MUTE_ON": (5, 3),
+            "MUTE_TOGGLE": (5, 4),
+            "PIC_MODE": (6, 0),
+            "PIC_SIZE": (6, 2),
+            "INPUT_NEXT": (7, 1),
+            "CH_DOWN": (8, 0),
+            "CH_UP": (8, 1),
+            "CH_PREV": (8, 2),
+            "EXIT": (9, 0),
+            "POW_OFF": (11, 0),
+            "POW_ON": (11, 1),
+            "POW_TOGGLE": (11, 2),
+        },
+    ),
+    DEVICE_CLASS_SPEAKER: DeviceConfig(
+        device_class=DEVICE_CLASS_SPEAKER,
+        requires_auth=False,
+        max_volume=31,
+        endpoints={
+            "BEGIN_PAIR": "/pairing/start",
+            "FINISH_PAIR": "/pairing/pair",
+            "CANCEL_PAIR": "/pairing/cancel",
+            "INPUTS": "/menu_native/dynamic/audio_settings/input",
+            "CURRENT_INPUT": "/menu_native/dynamic/audio_settings/input/current_input",
+            "ESN": "/menu_native/dynamic/audio_settings/system/system_information/uli_information/esn",
+            "SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/serial_number",
+            "VERSION": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/version",
+            "_ALT_ESN": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/uli_information/esn",
+            "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/serial_number",
+            "_ALT_VERSION": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/version",
+            "DEVICE_INFO": "/state/device/deviceinfo",
+            "POWER_MODE": "/state/device/power_mode",
+            "KEY_PRESS": "/key_command/",
+            "SETTINGS": "/menu_native/dynamic/audio_settings",
+            "SETTINGS_OPTIONS": "/menu_native/static/audio_settings",
+        },
+        key_codes={
+            "PAUSE": (2, 2),
+            "PLAY": (2, 3),
+            "VOL_DOWN": (5, 0),
+            "VOL_UP": (5, 1),
+            "MUTE_OFF": (5, 2),
+            "MUTE_ON": (5, 3),
+            "MUTE_TOGGLE": (5, 4),
+            "POW_OFF": (11, 0),
+            "POW_ON": (11, 1),
+            "POW_TOGGLE": (11, 2),
+        },
+    ),
+    DEVICE_CLASS_CRAVE360: DeviceConfig(
+        device_class=DEVICE_CLASS_CRAVE360,
+        requires_auth=False,
+        max_volume=100,
+        endpoints={
+            "BEGIN_PAIR": "/pairing/start",
+            "FINISH_PAIR": "/pairing/pair",
+            "CANCEL_PAIR": "/pairing/cancel",
+            "INPUTS": "/menu_native/dynamic/audio_settings/input",
+            "CURRENT_INPUT": "/menu_native/dynamic/audio_settings/input/current_input",
+            "ESN": "/menu_native/dynamic/audio_settings/system/system_information/uli_information/esn",
+            "SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/serial_number",
+            "VERSION": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/version",
+            "_ALT_ESN": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/uli_information/esn",
+            "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/serial_number",
+            "_ALT_VERSION": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/version",
+            "DEVICE_INFO": "/state/device/deviceinfo",
+            "POWER_MODE": "/state/device/power_mode",
+            "KEY_PRESS": "/key_command/",
+            "SETTINGS": "/menu_native/dynamic/audio_settings",
+            "SETTINGS_OPTIONS": "/menu_native/static/audio_settings",
+            "CHARGING_STATUS": "/state/device/charging_status",
+            "BATTERY_LEVEL": "/state/device/battery_level",
+        },
+        key_codes={
+            "PAUSE": (2, 2),
+            "PLAY": (2, 3),
+            "VOL_DOWN": (5, 0),
+            "VOL_UP": (5, 1),
+            "MUTE_OFF": (5, 2),
+            "MUTE_ON": (5, 3),
+            "MUTE_TOGGLE": (5, 4),
+            "POW_OFF": (11, 0),
+            "POW_ON": (11, 1),
+            "POW_TOGGLE": (11, 2),
+        },
+    ),
+}


### PR DESCRIPTION
## Summary
- Add frozen `DeviceConfig` dataclass in `const.py` consolidating endpoints, key codes, max volume, and auth requirements per device class
- Derive `ENDPOINT` and `KEY_CODE` dicts in `_protocol.py` from `DEVICE_CONFIGS` (single source of truth)
- Replace hardcoded device type validation and auth checks with `DEVICE_CONFIGS` lookups in `__init__.py`

## Test plan
- [x] `uv run pytest tests/` — 203 tests pass
- [x] `uv run --extra dev mypy --warn-unused-ignores pyvizio/` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)