### PR TITLE
refactor: add semaphore-based request throttling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,16 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-requests
+          - types-tabulate
+        args: [--ignore-missing-imports]
+        files: ^pyvizio/.+\.py$
+
   - repo: local
     hooks:
       - id: build-check

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -70,7 +70,7 @@ from pyvizio.discovery.zeroconf import ZeroconfDevice, discover as discover_zc
 from pyvizio.errors import (
     VizioAuthError,
     VizioConnectionError as VizioConnectionError,
-    VizioError,
+    VizioError as VizioError,
     VizioInvalidParameterError as VizioInvalidParameterError,
     VizioResponseError as VizioResponseError,
 )
@@ -97,7 +97,7 @@ class VizioAsync:
         """Initialize asynchronous class to interact with Vizio SmartCast devices."""
         self.device_type = device_type.lower()
         if self.device_type not in DEVICE_CONFIGS:
-            raise VizioError(
+            raise VizioInvalidParameterError(
                 f"Invalid device type specified. Use one of: "
                 f"{', '.join(repr(k) for k in DEVICE_CONFIGS)}"
             )
@@ -820,7 +820,7 @@ async def async_guess_device_type(
 
     if port:
         if ":" in ip:
-            raise VizioError(
+            raise VizioInvalidParameterError(
                 "Port can't be included in both `ip` and `port` parameters"
             )
 

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -93,6 +93,7 @@ class VizioAsync:
         device_type: str = DEFAULT_DEVICE_CLASS,
         session: ClientSession | None = None,
         timeout: int = DEFAULT_TIMEOUT,
+        max_concurrent_requests: int = 1,
     ) -> None:
         """Initialize asynchronous class to interact with Vizio SmartCast devices."""
         self.device_type = device_type.lower()
@@ -109,6 +110,8 @@ class VizioAsync:
         self.device_id = device_id
         self._session = session
         self._timeout = timeout
+        self._max_concurrent_requests = max_concurrent_requests
+        self._semaphore: asyncio.Semaphore | None = None
         self._latest_apps: list[dict[str, Any]] | None = None
         self._latest_apps_last_updated: datetime | None = None
 
@@ -116,13 +119,32 @@ class VizioAsync:
         return f"{type(self).__name__}({self.__dict__})"
 
     def __eq__(self, other) -> bool:
-        return self is other or self.__dict__ == other.__dict__
+        if self is other:
+            return True
+        exclude = {"_semaphore", "_max_concurrent_requests"}
+        self_d = {k: v for k, v in self.__dict__.items() if k not in exclude}
+        other_d = {k: v for k, v in other.__dict__.items() if k not in exclude}
+        return self_d == other_d
+
+    def _get_semaphore(self) -> asyncio.Semaphore:
+        """Lazily create semaphore (Python 3.9 requires a running event loop)."""
+        if self._semaphore is None:
+            self._semaphore = asyncio.Semaphore(self._max_concurrent_requests)
+        return self._semaphore
 
     async def __add_port(self) -> None:
         """Asynchronously add first open port from known ports list to `ip` property."""
         for port in DEFAULT_PORTS:
             if await open_port(self.ip, port):
                 self.ip = f"{self.ip}:{port}"
+
+    async def connect(self) -> None:
+        """Eagerly resolve port if not already specified.
+
+        This is optional — lazy resolution still works if connect() is not called.
+        """
+        if ":" not in self.ip:
+            await self.__add_port()
 
     async def __invoke_api(
         self, cmd: CommandBase, log_api_exception: bool = True
@@ -131,14 +153,15 @@ class VizioAsync:
         if ":" not in self.ip:
             await self.__add_port()
 
-        return await async_invoke_api(
-            self.ip,
-            cmd,
-            _LOGGER,
-            custom_timeout=self._timeout,
-            log_api_exception=log_api_exception,
-            session=self._session,
-        )
+        async with self._get_semaphore():
+            return await async_invoke_api(
+                self.ip,
+                cmd,
+                _LOGGER,
+                custom_timeout=self._timeout,
+                log_api_exception=log_api_exception,
+                session=self._session,
+            )
 
     async def __invoke_api_auth(
         self, cmd: CommandBase, log_api_exception: bool = True
@@ -147,15 +170,16 @@ class VizioAsync:
         if ":" not in self.ip:
             await self.__add_port()
 
-        return await async_invoke_api_auth(
-            self.ip,
-            cmd,
-            _LOGGER,
-            auth_token=self._auth_token,
-            custom_timeout=self._timeout,
-            log_api_exception=log_api_exception,
-            session=self._session,
-        )
+        async with self._get_semaphore():
+            return await async_invoke_api_auth(
+                self.ip,
+                cmd,
+                _LOGGER,
+                auth_token=self._auth_token,
+                custom_timeout=self._timeout,
+                log_api_exception=log_api_exception,
+                session=self._session,
+            )
 
     async def __invoke_api_may_need_auth(
         self, cmd: CommandBase, log_api_exception: bool = True
@@ -935,7 +959,8 @@ if TYPE_CHECKING:
     # fmt: off
     # Stubs so type checkers/IDEs see the sync signatures on Vizio.
     class Vizio(VizioAsync):  # type: ignore[no-redef]
-        def __init__(self, device_id: str, ip: str, name: str, auth_token: str = "", device_type: str = DEFAULT_DEVICE_CLASS, timeout: int = DEFAULT_TIMEOUT) -> None: ...
+        def __init__(self, device_id: str, ip: str, name: str, auth_token: str = "", device_type: str = DEFAULT_DEVICE_CLASS, timeout: int = DEFAULT_TIMEOUT, max_concurrent_requests: int = 1) -> None: ...
+        def connect(self) -> None: ...  # type: ignore[override]
         @staticmethod
         def validate_ha_config(ip: str, auth_token: str, device_type: str, session: ClientSession | None = None, timeout: int = DEFAULT_TIMEOUT) -> bool: ...  # type: ignore[override]
         @staticmethod

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -110,6 +110,8 @@ class VizioAsync:
         self.device_id = device_id
         self._session = session
         self._timeout = timeout
+        if max_concurrent_requests < 1:
+            raise VizioInvalidParameterError("max_concurrent_requests must be >= 1")
         self._max_concurrent_requests = max_concurrent_requests
         self._semaphore: asyncio.Semaphore | None = None
         self._latest_apps: list[dict[str, Any]] | None = None
@@ -118,9 +120,11 @@ class VizioAsync:
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.__dict__})"
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         if self is other:
             return True
+        if not isinstance(other, VizioAsync):
+            return NotImplemented
         exclude = {"_semaphore", "_max_concurrent_requests"}
         self_d = {k: v for k, v in self.__dict__.items() if k not in exclude}
         other_d = {k: v for k, v in other.__dict__.items() if k not in exclude}
@@ -150,10 +154,10 @@ class VizioAsync:
         self, cmd: CommandBase, log_api_exception: bool = True
     ) -> Any:
         """Asynchronously call SmartCast API without auth token."""
-        if ":" not in self.ip:
-            await self.__add_port()
-
         async with self._get_semaphore():
+            if ":" not in self.ip:
+                await self.__add_port()
+
             return await async_invoke_api(
                 self.ip,
                 cmd,
@@ -167,10 +171,10 @@ class VizioAsync:
         self, cmd: CommandBase, log_api_exception: bool = True
     ) -> Any:
         """Asynchronously call SmartCast API with auth token."""
-        if ":" not in self.ip:
-            await self.__add_port()
-
         async with self._get_semaphore():
+            if ":" not in self.ip:
+                await self.__add_port()
+
             return await async_invoke_api_auth(
                 self.ip,
                 cmd,

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -59,10 +59,11 @@ from pyvizio.const import (
     DEFAULT_DEVICE_CLASS,
     DEFAULT_PORTS,
     DEFAULT_TIMEOUT,
-    DEVICE_CLASS_CRAVE360,
+    DEVICE_CLASS_CRAVE360 as DEVICE_CLASS_CRAVE360,
     DEVICE_CLASS_SPEAKER,
     DEVICE_CLASS_TV,
-    MAX_VOLUME,
+    DEVICE_CONFIGS,
+    MAX_VOLUME as MAX_VOLUME,
 )
 from pyvizio.discovery.ssdp import SSDPDevice, discover as discover_ssdp
 from pyvizio.discovery.zeroconf import ZeroconfDevice, discover as discover_zc
@@ -88,15 +89,12 @@ class VizioAsync:
     ) -> None:
         """Initialize asynchronous class to interact with Vizio SmartCast devices."""
         self.device_type = device_type.lower()
-        if (
-            self.device_type != DEVICE_CLASS_TV
-            and self.device_type != DEVICE_CLASS_SPEAKER
-            and self.device_type != DEVICE_CLASS_CRAVE360
-        ):
+        if self.device_type not in DEVICE_CONFIGS:
             raise Exception(
-                f"Invalid device type specified. Use either '{DEVICE_CLASS_TV}' or "
-                f"'{DEVICE_CLASS_SPEAKER}' or '{DEVICE_CLASS_CRAVE360}''"
+                f"Invalid device type specified. Use one of: "
+                f"{', '.join(repr(k) for k in DEVICE_CONFIGS)}"
             )
+        self._device_config = DEVICE_CONFIGS[self.device_type]
 
         self._auth_token = auth_token
         self.ip = ip
@@ -157,15 +155,15 @@ class VizioAsync:
     ) -> Any:
         """Asynchronously call SmartCast API command with or without auth token depending on device type."""
         if not self._auth_token:
-            if (
-                self.device_type == DEVICE_CLASS_SPEAKER
-                or self.device_type == DEVICE_CLASS_CRAVE360
-            ):
+            if not self._device_config.requires_auth:
                 return await self.__invoke_api(cmd, log_api_exception=log_api_exception)
             else:
+                no_auth_types = [
+                    k for k, v in DEVICE_CONFIGS.items() if not v.requires_auth
+                ]
                 raise Exception(
-                    f"Empty auth token. To target a speaker and bypass auth "
-                    f"requirements, pass '{DEVICE_CLASS_SPEAKER}' as device_type"
+                    f"Empty auth token. Device types that don't require auth: "
+                    f"{', '.join(repr(t) for t in no_auth_types)}"
                 )
         return await self.__invoke_api_auth(cmd, log_api_exception=log_api_exception)
 
@@ -507,7 +505,7 @@ class VizioAsync:
 
     def get_max_volume(self) -> int:
         """Get device's max volume based on device type."""
-        return MAX_VOLUME[self.device_type]
+        return self._device_config.max_volume
 
     async def ch_up(self, num: int = 1, log_api_exception: bool = True) -> bool | None:
         """Asynchronously channel up by number of steps."""

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -67,6 +67,13 @@ from pyvizio.const import (
 )
 from pyvizio.discovery.ssdp import SSDPDevice, discover as discover_ssdp
 from pyvizio.discovery.zeroconf import ZeroconfDevice, discover as discover_zc
+from pyvizio.errors import (
+    VizioAuthError,
+    VizioConnectionError as VizioConnectionError,
+    VizioError,
+    VizioInvalidParameterError as VizioInvalidParameterError,
+    VizioResponseError as VizioResponseError,
+)
 from pyvizio.helpers import async_to_sync, open_port
 from pyvizio.util import gen_apps_list_from_url
 from pyvizio.version import __version__ as __version__
@@ -90,7 +97,7 @@ class VizioAsync:
         """Initialize asynchronous class to interact with Vizio SmartCast devices."""
         self.device_type = device_type.lower()
         if self.device_type not in DEVICE_CONFIGS:
-            raise Exception(
+            raise VizioError(
                 f"Invalid device type specified. Use one of: "
                 f"{', '.join(repr(k) for k in DEVICE_CONFIGS)}"
             )
@@ -161,7 +168,7 @@ class VizioAsync:
                 no_auth_types = [
                     k for k, v in DEVICE_CONFIGS.items() if not v.requires_auth
                 ]
-                raise Exception(
+                raise VizioAuthError(
                     f"Empty auth token. Device types that don't require auth: "
                     f"{', '.join(repr(t) for t in no_auth_types)}"
                 )
@@ -813,7 +820,9 @@ async def async_guess_device_type(
 
     if port:
         if ":" in ip:
-            raise Exception("Port can't be included in both `ip` and `port` parameters")
+            raise VizioError(
+                "Port can't be included in both `ip` and `port` parameters"
+            )
 
         device = VizioAsync(
             "test", f"{ip}:{port}", "test", "", DEVICE_CLASS_SPEAKER, timeout=timeout

--- a/pyvizio/api/_protocol.py
+++ b/pyvizio/api/_protocol.py
@@ -11,6 +11,11 @@ from aiohttp.client import DEFAULT_TIMEOUT as AIOHTTP_DEFAULT_TIMEOUT
 
 from pyvizio.api.base import CommandBase
 from pyvizio.const import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV, DEVICE_CONFIGS
+from pyvizio.errors import (
+    VizioConnectionError,
+    VizioInvalidParameterError,
+    VizioResponseError,
+)
 from pyvizio.helpers import dict_get_case_insensitive
 
 _LOGGER = getLogger(__name__)
@@ -84,25 +89,29 @@ class ResponseKey:
 async def async_validate_response(web_response: ClientResponse) -> dict[str, Any]:
     """Validate response to API command is as expected and return response."""
     if HTTP_OK != web_response.status:
-        raise Exception(f"Device is unreachable? Status code: {web_response.status}")
+        raise VizioConnectionError(
+            f"Device is unreachable? Status code: {web_response.status}"
+        )
 
     try:
         data = json.loads(await web_response.text())
         _LOGGER.debug("Response: %s", data)
     except Exception as err:
-        raise Exception(f"Failed to parse response: {web_response.content}") from err
+        raise VizioResponseError(
+            f"Failed to parse response: {web_response.content}"
+        ) from err
 
     status_obj = dict_get_case_insensitive(data, "status")
 
     if not status_obj:
-        raise Exception("Unknown response")
+        raise VizioResponseError("Unknown response")
 
     result_status = dict_get_case_insensitive(status_obj, "result")
 
     if result_status and result_status.lower() == STATUS_INVALID_PARAMETER:
-        raise Exception("invalid value specified")
+        raise VizioInvalidParameterError("invalid value specified")
     elif not result_status or result_status.lower() != STATUS_SUCCESS:
-        raise Exception(
+        raise VizioResponseError(
             "unexpected status {}: {}".format(
                 result_status, dict_get_case_insensitive(status_obj, "detail")
             )

--- a/pyvizio/api/_protocol.py
+++ b/pyvizio/api/_protocol.py
@@ -10,7 +10,7 @@ from aiohttp import ClientResponse, ClientSession, ClientTimeout
 from aiohttp.client import DEFAULT_TIMEOUT as AIOHTTP_DEFAULT_TIMEOUT
 
 from pyvizio.api.base import CommandBase
-from pyvizio.const import DEVICE_CLASS_CRAVE360, DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
+from pyvizio.const import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV, DEVICE_CONFIGS
 from pyvizio.helpers import dict_get_case_insensitive
 
 _LOGGER = getLogger(__name__)
@@ -31,66 +31,8 @@ TYPE_VALUE = "t_value_v1"
 TYPE_MENU = "t_menu_v1"
 TYPE_X_LIST = "t_list_x_v1"
 
-ENDPOINT = {
-    DEVICE_CLASS_TV: {
-        "BEGIN_PAIR": "/pairing/start",
-        "FINISH_PAIR": "/pairing/pair",
-        "CANCEL_PAIR": "/pairing/cancel",
-        "INPUTS": "/menu_native/dynamic/tv_settings/devices/name_input",
-        "CURRENT_INPUT": "/menu_native/dynamic/tv_settings/devices/current_input",
-        "ESN": "/menu_native/dynamic/tv_settings/system/system_information/uli_information/esn",
-        "SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/system/system_information/tv_information/serial_number",
-        "VERSION": "/menu_native/dynamic/tv_settings/system/system_information/tv_information/version",
-        "_ALT_ESN": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/uli_information/esn",
-        "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/serial_number",
-        "_ALT_VERSION": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/version",
-        "DEVICE_INFO": "/state/device/deviceinfo",
-        "POWER_MODE": "/state/device/power_mode",
-        "KEY_PRESS": "/key_command/",
-        "SETTINGS": "/menu_native/dynamic/tv_settings",
-        "SETTINGS_OPTIONS": "/menu_native/static/tv_settings",
-        "CURRENT_APP": "/app/current",
-        "LAUNCH_APP": "/app/launch",
-    },
-    DEVICE_CLASS_SPEAKER: {
-        "BEGIN_PAIR": "/pairing/start",
-        "FINISH_PAIR": "/pairing/pair",
-        "CANCEL_PAIR": "/pairing/cancel",
-        "INPUTS": "/menu_native/dynamic/audio_settings/input",
-        "CURRENT_INPUT": "/menu_native/dynamic/audio_settings/input/current_input",
-        "ESN": "/menu_native/dynamic/audio_settings/system/system_information/uli_information/esn",
-        "SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/serial_number",
-        "VERSION": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/version",
-        "_ALT_ESN": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/uli_information/esn",
-        "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/serial_number",
-        "_ALT_VERSION": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/version",
-        "DEVICE_INFO": "/state/device/deviceinfo",
-        "POWER_MODE": "/state/device/power_mode",
-        "KEY_PRESS": "/key_command/",
-        "SETTINGS": "/menu_native/dynamic/audio_settings",
-        "SETTINGS_OPTIONS": "/menu_native/static/audio_settings",
-    },
-    DEVICE_CLASS_CRAVE360: {
-        "BEGIN_PAIR": "/pairing/start",
-        "FINISH_PAIR": "/pairing/pair",
-        "CANCEL_PAIR": "/pairing/cancel",
-        "INPUTS": "/menu_native/dynamic/audio_settings/input",
-        "CURRENT_INPUT": "/menu_native/dynamic/audio_settings/input/current_input",
-        "ESN": "/menu_native/dynamic/audio_settings/system/system_information/uli_information/esn",
-        "SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/serial_number",
-        "VERSION": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/version",
-        "_ALT_ESN": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/uli_information/esn",
-        "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/serial_number",
-        "_ALT_VERSION": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/version",
-        "DEVICE_INFO": "/state/device/deviceinfo",
-        "POWER_MODE": "/state/device/power_mode",
-        "KEY_PRESS": "/key_command/",
-        "SETTINGS": "/menu_native/dynamic/audio_settings",
-        "SETTINGS_OPTIONS": "/menu_native/static/audio_settings",
-        "CHARGING_STATUS": "/state/device/charging_status",
-        "BATTERY_LEVEL": "/state/device/battery_level",
-    },
-}
+# Derived from DEVICE_CONFIGS — single source of truth in const.py
+ENDPOINT = {k: v.endpoints for k, v in DEVICE_CONFIGS.items()}
 
 ITEM_CNAME = {
     "CURRENT_INPUT": "current_input",
@@ -105,65 +47,8 @@ ITEM_CNAME = {
 
 KEY_ACTION = {"DOWN": "KEYDOWN", "UP": "KEYUP", "PRESS": "KEYPRESS"}
 
-KEY_CODE = {
-    DEVICE_CLASS_TV: {
-        "SEEK_FWD": (2, 0),
-        "SEEK_BACK": (2, 1),
-        "PAUSE": (2, 2),
-        "PLAY": (2, 3),
-        "DOWN": (3, 0),
-        "LEFT": (3, 1),
-        "OK": (3, 2),
-        "UP": (3, 8),
-        "LEFT2": (3, 4),
-        "RIGHT": (3, 7),
-        "BACK": (4, 0),
-        "SMARTCAST": (4, 3),
-        "CC_TOGGLE": (4, 4),
-        "INFO": (4, 6),
-        "MENU": (4, 8),
-        "HOME": (4, 15),
-        "VOL_DOWN": (5, 0),
-        "VOL_UP": (5, 1),
-        "MUTE_OFF": (5, 2),
-        "MUTE_ON": (5, 3),
-        "MUTE_TOGGLE": (5, 4),
-        "PIC_MODE": (6, 0),
-        "PIC_SIZE": (6, 2),
-        "INPUT_NEXT": (7, 1),
-        "CH_DOWN": (8, 0),
-        "CH_UP": (8, 1),
-        "CH_PREV": (8, 2),
-        "EXIT": (9, 0),
-        "POW_OFF": (11, 0),
-        "POW_ON": (11, 1),
-        "POW_TOGGLE": (11, 2),
-    },
-    DEVICE_CLASS_SPEAKER: {
-        "PAUSE": (2, 2),
-        "PLAY": (2, 3),
-        "VOL_DOWN": (5, 0),
-        "VOL_UP": (5, 1),
-        "MUTE_OFF": (5, 2),
-        "MUTE_ON": (5, 3),
-        "MUTE_TOGGLE": (5, 4),
-        "POW_OFF": (11, 0),
-        "POW_ON": (11, 1),
-        "POW_TOGGLE": (11, 2),
-    },
-    DEVICE_CLASS_CRAVE360: {
-        "PAUSE": (2, 2),
-        "PLAY": (2, 3),
-        "VOL_DOWN": (5, 0),
-        "VOL_UP": (5, 1),
-        "MUTE_OFF": (5, 2),
-        "MUTE_ON": (5, 3),
-        "MUTE_TOGGLE": (5, 4),
-        "POW_OFF": (11, 0),
-        "POW_ON": (11, 1),
-        "POW_TOGGLE": (11, 2),
-    },
-}
+# Derived from DEVICE_CONFIGS — single source of truth in const.py
+KEY_CODE = {k: v.key_codes for k, v in DEVICE_CONFIGS.items()}
 
 PATH_MODEL = {
     DEVICE_CLASS_SPEAKER: [["name"]],

--- a/pyvizio/const.py
+++ b/pyvizio/const.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from importlib import resources
 import json
-from typing import Any
 
 DEVICE_CLASS_SPEAKER = "speaker"
 DEVICE_CLASS_TV = "tv"
@@ -48,10 +48,155 @@ APP_HOME = {
 }
 
 
-def _load_apps() -> list[dict[str, Any]]:
+def _load_apps() -> list[dict]:
     """Load apps list from bundled JSON data."""
     ref = resources.files("pyvizio.data").joinpath("apps.json")
     return json.loads(ref.read_text(encoding="utf-8"))
 
 
-APPS: list[dict[str, Any]] = _load_apps()
+APPS: list[dict] = _load_apps()
+
+
+@dataclass(frozen=True)
+class DeviceConfig:
+    """Configuration for a specific Vizio device class."""
+
+    device_class: str
+    requires_auth: bool
+    max_volume: int
+    endpoints: dict[str, str] = field(repr=False)
+    key_codes: dict[str, tuple[int, int]] = field(repr=False)
+
+
+DEVICE_CONFIGS: dict[str, DeviceConfig] = {
+    DEVICE_CLASS_TV: DeviceConfig(
+        device_class=DEVICE_CLASS_TV,
+        requires_auth=True,
+        max_volume=100,
+        endpoints={
+            "BEGIN_PAIR": "/pairing/start",
+            "FINISH_PAIR": "/pairing/pair",
+            "CANCEL_PAIR": "/pairing/cancel",
+            "INPUTS": "/menu_native/dynamic/tv_settings/devices/name_input",
+            "CURRENT_INPUT": "/menu_native/dynamic/tv_settings/devices/current_input",
+            "ESN": "/menu_native/dynamic/tv_settings/system/system_information/uli_information/esn",
+            "SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/system/system_information/tv_information/serial_number",
+            "VERSION": "/menu_native/dynamic/tv_settings/system/system_information/tv_information/version",
+            "_ALT_ESN": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/uli_information/esn",
+            "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/serial_number",
+            "_ALT_VERSION": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/version",
+            "DEVICE_INFO": "/state/device/deviceinfo",
+            "POWER_MODE": "/state/device/power_mode",
+            "KEY_PRESS": "/key_command/",
+            "SETTINGS": "/menu_native/dynamic/tv_settings",
+            "SETTINGS_OPTIONS": "/menu_native/static/tv_settings",
+            "CURRENT_APP": "/app/current",
+            "LAUNCH_APP": "/app/launch",
+        },
+        key_codes={
+            "SEEK_FWD": (2, 0),
+            "SEEK_BACK": (2, 1),
+            "PAUSE": (2, 2),
+            "PLAY": (2, 3),
+            "DOWN": (3, 0),
+            "LEFT": (3, 1),
+            "OK": (3, 2),
+            "UP": (3, 8),
+            "LEFT2": (3, 4),
+            "RIGHT": (3, 7),
+            "BACK": (4, 0),
+            "SMARTCAST": (4, 3),
+            "CC_TOGGLE": (4, 4),
+            "INFO": (4, 6),
+            "MENU": (4, 8),
+            "HOME": (4, 15),
+            "VOL_DOWN": (5, 0),
+            "VOL_UP": (5, 1),
+            "MUTE_OFF": (5, 2),
+            "MUTE_ON": (5, 3),
+            "MUTE_TOGGLE": (5, 4),
+            "PIC_MODE": (6, 0),
+            "PIC_SIZE": (6, 2),
+            "INPUT_NEXT": (7, 1),
+            "CH_DOWN": (8, 0),
+            "CH_UP": (8, 1),
+            "CH_PREV": (8, 2),
+            "EXIT": (9, 0),
+            "POW_OFF": (11, 0),
+            "POW_ON": (11, 1),
+            "POW_TOGGLE": (11, 2),
+        },
+    ),
+    DEVICE_CLASS_SPEAKER: DeviceConfig(
+        device_class=DEVICE_CLASS_SPEAKER,
+        requires_auth=False,
+        max_volume=31,
+        endpoints={
+            "BEGIN_PAIR": "/pairing/start",
+            "FINISH_PAIR": "/pairing/pair",
+            "CANCEL_PAIR": "/pairing/cancel",
+            "INPUTS": "/menu_native/dynamic/audio_settings/input",
+            "CURRENT_INPUT": "/menu_native/dynamic/audio_settings/input/current_input",
+            "ESN": "/menu_native/dynamic/audio_settings/system/system_information/uli_information/esn",
+            "SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/serial_number",
+            "VERSION": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/version",
+            "_ALT_ESN": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/uli_information/esn",
+            "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/serial_number",
+            "_ALT_VERSION": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/version",
+            "DEVICE_INFO": "/state/device/deviceinfo",
+            "POWER_MODE": "/state/device/power_mode",
+            "KEY_PRESS": "/key_command/",
+            "SETTINGS": "/menu_native/dynamic/audio_settings",
+            "SETTINGS_OPTIONS": "/menu_native/static/audio_settings",
+        },
+        key_codes={
+            "PAUSE": (2, 2),
+            "PLAY": (2, 3),
+            "VOL_DOWN": (5, 0),
+            "VOL_UP": (5, 1),
+            "MUTE_OFF": (5, 2),
+            "MUTE_ON": (5, 3),
+            "MUTE_TOGGLE": (5, 4),
+            "POW_OFF": (11, 0),
+            "POW_ON": (11, 1),
+            "POW_TOGGLE": (11, 2),
+        },
+    ),
+    DEVICE_CLASS_CRAVE360: DeviceConfig(
+        device_class=DEVICE_CLASS_CRAVE360,
+        requires_auth=False,
+        max_volume=100,
+        endpoints={
+            "BEGIN_PAIR": "/pairing/start",
+            "FINISH_PAIR": "/pairing/pair",
+            "CANCEL_PAIR": "/pairing/cancel",
+            "INPUTS": "/menu_native/dynamic/audio_settings/input",
+            "CURRENT_INPUT": "/menu_native/dynamic/audio_settings/input/current_input",
+            "ESN": "/menu_native/dynamic/audio_settings/system/system_information/uli_information/esn",
+            "SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/serial_number",
+            "VERSION": "/menu_native/dynamic/audio_settings/system/system_information/speaker_information/version",
+            "_ALT_ESN": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/uli_information/esn",
+            "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/serial_number",
+            "_ALT_VERSION": "/menu_native/dynamic/audio_settings/admin_and_privacy/system_information/speaker_information/version",
+            "DEVICE_INFO": "/state/device/deviceinfo",
+            "POWER_MODE": "/state/device/power_mode",
+            "KEY_PRESS": "/key_command/",
+            "SETTINGS": "/menu_native/dynamic/audio_settings",
+            "SETTINGS_OPTIONS": "/menu_native/static/audio_settings",
+            "CHARGING_STATUS": "/state/device/charging_status",
+            "BATTERY_LEVEL": "/state/device/battery_level",
+        },
+        key_codes={
+            "PAUSE": (2, 2),
+            "PLAY": (2, 3),
+            "VOL_DOWN": (5, 0),
+            "VOL_UP": (5, 1),
+            "MUTE_OFF": (5, 2),
+            "MUTE_ON": (5, 3),
+            "MUTE_TOGGLE": (5, 4),
+            "POW_OFF": (11, 0),
+            "POW_ON": (11, 1),
+            "POW_TOGGLE": (11, 2),
+        },
+    ),
+}

--- a/pyvizio/errors.py
+++ b/pyvizio/errors.py
@@ -1,0 +1,23 @@
+"""pyvizio exception hierarchy."""
+
+from __future__ import annotations
+
+
+class VizioError(Exception):
+    """Base exception for pyvizio."""
+
+
+class VizioConnectionError(VizioError):
+    """Device is unreachable or connection failed."""
+
+
+class VizioAuthError(VizioError):
+    """Authentication failed or auth token is missing/invalid."""
+
+
+class VizioInvalidParameterError(VizioError):
+    """Invalid parameter value was specified."""
+
+
+class VizioResponseError(VizioError):
+    """Unexpected or malformed response from device."""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -130,10 +130,10 @@ class TestAuthError:
 
 
 class TestDeviceTypeError:
-    """Test that invalid device types raise VizioError."""
+    """Test that invalid device types raise VizioInvalidParameterError."""
 
     def test_invalid_device_type_raises(self):
-        with pytest.raises(VizioError, match="Invalid device type"):
+        with pytest.raises(VizioInvalidParameterError, match="Invalid device type"):
             VizioAsync("pyvizio", TV_IP_PORT, "TV", AUTH_TOKEN, "invalid")
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,156 @@
+"""Tests for pyvizio error types and their usage."""
+
+from __future__ import annotations
+
+from aioresponses import aioresponses
+import pytest
+
+from pyvizio import VizioAsync
+from pyvizio.api._protocol import async_validate_response
+from pyvizio.errors import (
+    VizioAuthError,
+    VizioConnectionError,
+    VizioError,
+    VizioInvalidParameterError,
+    VizioResponseError,
+)
+from tests.conftest import (
+    AUTH_TOKEN,
+    TV_IP_PORT,
+    make_error_response,
+    make_power_response,
+    tv_url,
+)
+
+
+class TestErrorHierarchy:
+    """Test that all errors inherit from VizioError."""
+
+    def test_base_error(self):
+        assert issubclass(VizioError, Exception)
+
+    def test_connection_error_inherits(self):
+        assert issubclass(VizioConnectionError, VizioError)
+
+    def test_auth_error_inherits(self):
+        assert issubclass(VizioAuthError, VizioError)
+
+    def test_invalid_parameter_error_inherits(self):
+        assert issubclass(VizioInvalidParameterError, VizioError)
+
+    def test_response_error_inherits(self):
+        assert issubclass(VizioResponseError, VizioError)
+
+    def test_catch_all_with_base(self):
+        """All typed errors should be catchable via VizioError."""
+        for exc_cls in (
+            VizioConnectionError,
+            VizioAuthError,
+            VizioInvalidParameterError,
+            VizioResponseError,
+        ):
+            with pytest.raises(VizioError):
+                raise exc_cls("test")
+
+
+class TestValidateResponseErrors:
+    """Test that async_validate_response raises typed exceptions."""
+
+    async def test_non_200_raises_connection_error(self):
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), status=500)
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioConnectionError, match="Status code: 500"):
+                    await async_validate_response(resp)
+
+    async def test_invalid_json_raises_response_error(self):
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), body="not json")
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioResponseError, match="Failed to parse"):
+                    await async_validate_response(resp)
+
+    async def test_missing_status_raises_response_error(self):
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), payload={"data": "no status"})
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioResponseError, match="Unknown response"):
+                    await async_validate_response(resp)
+
+    async def test_invalid_parameter_raises_typed_error(self):
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), payload=make_error_response())
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioInvalidParameterError):
+                    await async_validate_response(resp)
+
+    async def test_unexpected_status_raises_response_error(self):
+        with aioresponses() as m:
+            m.get(
+                tv_url("POWER_MODE"),
+                payload=make_error_response(result="FAILURE", detail="Something broke"),
+            )
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioResponseError, match="unexpected status"):
+                    await async_validate_response(resp)
+
+
+class TestAuthError:
+    """Test that auth errors are raised correctly."""
+
+    async def test_tv_without_auth_raises_auth_error(self):
+        vizio = VizioAsync("pyvizio", TV_IP_PORT, "TV", "", "tv")
+        with pytest.raises(VizioAuthError, match="Empty auth token"):
+            await vizio.get_power_state()
+
+    async def test_speaker_without_auth_does_not_raise(self):
+        """Speakers don't require auth, so no error should be raised."""
+        from tests.conftest import SPEAKER_IP_PORT, speaker_url
+
+        vizio = VizioAsync("pyvizio", SPEAKER_IP_PORT, "Speaker", "", "speaker")
+        with aioresponses() as m:
+            m.get(speaker_url("POWER_MODE"), payload=make_power_response(1))
+            result = await vizio.get_power_state()
+        assert result is True
+
+
+class TestDeviceTypeError:
+    """Test that invalid device types raise VizioError."""
+
+    def test_invalid_device_type_raises(self):
+        with pytest.raises(VizioError, match="Invalid device type"):
+            VizioAsync("pyvizio", TV_IP_PORT, "TV", AUTH_TOKEN, "invalid")
+
+
+class TestInvokeApiPreservesNoneReturn:
+    """Test that typed exceptions from validate_response are caught by invoke_api,
+    preserving the existing None-return behavior."""
+
+    async def test_connection_error_returns_none(self):
+        vizio = VizioAsync("pyvizio", TV_IP_PORT, "TV", AUTH_TOKEN, "tv")
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), status=500)
+            result = await vizio.get_power_state(log_api_exception=False)
+        assert result is None
+
+    async def test_invalid_param_returns_none(self):
+        vizio = VizioAsync("pyvizio", TV_IP_PORT, "TV", AUTH_TOKEN, "tv")
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), payload=make_error_response())
+            result = await vizio.get_power_state(log_api_exception=False)
+        assert result is None


### PR DESCRIPTION
## Summary
- Add `max_concurrent_requests` parameter to `VizioAsync.__init__` with lazy semaphore creation
- Wrap `__invoke_api` and `__invoke_api_auth` with semaphore for concurrency control
- Add `connect()` method for eager port resolution
- Update `__eq__` to exclude transient semaphore state
- Add mypy hook to `.pre-commit-config.yaml`

## Dependencies
- Depends on #189 (error-types) and #188 (device-config)

## Test plan
- [x] `uv run pytest tests/` — 219 tests pass
- [x] `uv run --extra dev mypy --warn-unused-ignores pyvizio/` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)