### PR TITLE
refactor: add typed exception hierarchy

### DIFF
--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -70,7 +70,7 @@ from pyvizio.discovery.zeroconf import ZeroconfDevice, discover as discover_zc
 from pyvizio.errors import (
     VizioAuthError,
     VizioConnectionError as VizioConnectionError,
-    VizioError,
+    VizioError as VizioError,
     VizioInvalidParameterError as VizioInvalidParameterError,
     VizioResponseError as VizioResponseError,
 )
@@ -97,7 +97,7 @@ class VizioAsync:
         """Initialize asynchronous class to interact with Vizio SmartCast devices."""
         self.device_type = device_type.lower()
         if self.device_type not in DEVICE_CONFIGS:
-            raise VizioError(
+            raise VizioInvalidParameterError(
                 f"Invalid device type specified. Use one of: "
                 f"{', '.join(repr(k) for k in DEVICE_CONFIGS)}"
             )
@@ -820,7 +820,7 @@ async def async_guess_device_type(
 
     if port:
         if ":" in ip:
-            raise VizioError(
+            raise VizioInvalidParameterError(
                 "Port can't be included in both `ip` and `port` parameters"
             )
 

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -67,6 +67,13 @@ from pyvizio.const import (
 )
 from pyvizio.discovery.ssdp import SSDPDevice, discover as discover_ssdp
 from pyvizio.discovery.zeroconf import ZeroconfDevice, discover as discover_zc
+from pyvizio.errors import (
+    VizioAuthError,
+    VizioConnectionError as VizioConnectionError,
+    VizioError,
+    VizioInvalidParameterError as VizioInvalidParameterError,
+    VizioResponseError as VizioResponseError,
+)
 from pyvizio.helpers import async_to_sync, open_port
 from pyvizio.util import gen_apps_list_from_url
 from pyvizio.version import __version__ as __version__
@@ -90,7 +97,7 @@ class VizioAsync:
         """Initialize asynchronous class to interact with Vizio SmartCast devices."""
         self.device_type = device_type.lower()
         if self.device_type not in DEVICE_CONFIGS:
-            raise Exception(
+            raise VizioError(
                 f"Invalid device type specified. Use one of: "
                 f"{', '.join(repr(k) for k in DEVICE_CONFIGS)}"
             )
@@ -161,7 +168,7 @@ class VizioAsync:
                 no_auth_types = [
                     k for k, v in DEVICE_CONFIGS.items() if not v.requires_auth
                 ]
-                raise Exception(
+                raise VizioAuthError(
                     f"Empty auth token. Device types that don't require auth: "
                     f"{', '.join(repr(t) for t in no_auth_types)}"
                 )
@@ -813,7 +820,9 @@ async def async_guess_device_type(
 
     if port:
         if ":" in ip:
-            raise Exception("Port can't be included in both `ip` and `port` parameters")
+            raise VizioError(
+                "Port can't be included in both `ip` and `port` parameters"
+            )
 
         device = VizioAsync(
             "test", f"{ip}:{port}", "test", "", DEVICE_CLASS_SPEAKER, timeout=timeout

--- a/pyvizio/api/_protocol.py
+++ b/pyvizio/api/_protocol.py
@@ -11,6 +11,11 @@ from aiohttp.client import DEFAULT_TIMEOUT as AIOHTTP_DEFAULT_TIMEOUT
 
 from pyvizio.api.base import CommandBase
 from pyvizio.const import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV, DEVICE_CONFIGS
+from pyvizio.errors import (
+    VizioConnectionError,
+    VizioInvalidParameterError,
+    VizioResponseError,
+)
 from pyvizio.helpers import dict_get_case_insensitive
 
 _LOGGER = getLogger(__name__)
@@ -84,25 +89,29 @@ class ResponseKey:
 async def async_validate_response(web_response: ClientResponse) -> dict[str, Any]:
     """Validate response to API command is as expected and return response."""
     if HTTP_OK != web_response.status:
-        raise Exception(f"Device is unreachable? Status code: {web_response.status}")
+        raise VizioConnectionError(
+            f"Device is unreachable? Status code: {web_response.status}"
+        )
 
     try:
         data = json.loads(await web_response.text())
         _LOGGER.debug("Response: %s", data)
     except Exception as err:
-        raise Exception(f"Failed to parse response: {web_response.content}") from err
+        raise VizioResponseError(
+            f"Failed to parse response: {web_response.content}"
+        ) from err
 
     status_obj = dict_get_case_insensitive(data, "status")
 
     if not status_obj:
-        raise Exception("Unknown response")
+        raise VizioResponseError("Unknown response")
 
     result_status = dict_get_case_insensitive(status_obj, "result")
 
     if result_status and result_status.lower() == STATUS_INVALID_PARAMETER:
-        raise Exception("invalid value specified")
+        raise VizioInvalidParameterError("invalid value specified")
     elif not result_status or result_status.lower() != STATUS_SUCCESS:
-        raise Exception(
+        raise VizioResponseError(
             "unexpected status {}: {}".format(
                 result_status, dict_get_case_insensitive(status_obj, "detail")
             )

--- a/pyvizio/errors.py
+++ b/pyvizio/errors.py
@@ -1,0 +1,23 @@
+"""pyvizio exception hierarchy."""
+
+from __future__ import annotations
+
+
+class VizioError(Exception):
+    """Base exception for pyvizio."""
+
+
+class VizioConnectionError(VizioError):
+    """Device is unreachable or connection failed."""
+
+
+class VizioAuthError(VizioError):
+    """Authentication failed or auth token is missing/invalid."""
+
+
+class VizioInvalidParameterError(VizioError):
+    """Invalid parameter value was specified."""
+
+
+class VizioResponseError(VizioError):
+    """Unexpected or malformed response from device."""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -130,10 +130,10 @@ class TestAuthError:
 
 
 class TestDeviceTypeError:
-    """Test that invalid device types raise VizioError."""
+    """Test that invalid device types raise VizioInvalidParameterError."""
 
     def test_invalid_device_type_raises(self):
-        with pytest.raises(VizioError, match="Invalid device type"):
+        with pytest.raises(VizioInvalidParameterError, match="Invalid device type"):
             VizioAsync("pyvizio", TV_IP_PORT, "TV", AUTH_TOKEN, "invalid")
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,156 @@
+"""Tests for pyvizio error types and their usage."""
+
+from __future__ import annotations
+
+from aioresponses import aioresponses
+import pytest
+
+from pyvizio import VizioAsync
+from pyvizio.api._protocol import async_validate_response
+from pyvizio.errors import (
+    VizioAuthError,
+    VizioConnectionError,
+    VizioError,
+    VizioInvalidParameterError,
+    VizioResponseError,
+)
+from tests.conftest import (
+    AUTH_TOKEN,
+    TV_IP_PORT,
+    make_error_response,
+    make_power_response,
+    tv_url,
+)
+
+
+class TestErrorHierarchy:
+    """Test that all errors inherit from VizioError."""
+
+    def test_base_error(self):
+        assert issubclass(VizioError, Exception)
+
+    def test_connection_error_inherits(self):
+        assert issubclass(VizioConnectionError, VizioError)
+
+    def test_auth_error_inherits(self):
+        assert issubclass(VizioAuthError, VizioError)
+
+    def test_invalid_parameter_error_inherits(self):
+        assert issubclass(VizioInvalidParameterError, VizioError)
+
+    def test_response_error_inherits(self):
+        assert issubclass(VizioResponseError, VizioError)
+
+    def test_catch_all_with_base(self):
+        """All typed errors should be catchable via VizioError."""
+        for exc_cls in (
+            VizioConnectionError,
+            VizioAuthError,
+            VizioInvalidParameterError,
+            VizioResponseError,
+        ):
+            with pytest.raises(VizioError):
+                raise exc_cls("test")
+
+
+class TestValidateResponseErrors:
+    """Test that async_validate_response raises typed exceptions."""
+
+    async def test_non_200_raises_connection_error(self):
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), status=500)
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioConnectionError, match="Status code: 500"):
+                    await async_validate_response(resp)
+
+    async def test_invalid_json_raises_response_error(self):
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), body="not json")
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioResponseError, match="Failed to parse"):
+                    await async_validate_response(resp)
+
+    async def test_missing_status_raises_response_error(self):
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), payload={"data": "no status"})
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioResponseError, match="Unknown response"):
+                    await async_validate_response(resp)
+
+    async def test_invalid_parameter_raises_typed_error(self):
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), payload=make_error_response())
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioInvalidParameterError):
+                    await async_validate_response(resp)
+
+    async def test_unexpected_status_raises_response_error(self):
+        with aioresponses() as m:
+            m.get(
+                tv_url("POWER_MODE"),
+                payload=make_error_response(result="FAILURE", detail="Something broke"),
+            )
+            from aiohttp import ClientSession
+
+            async with ClientSession() as session:
+                resp = await session.get(tv_url("POWER_MODE"), ssl=False)
+                with pytest.raises(VizioResponseError, match="unexpected status"):
+                    await async_validate_response(resp)
+
+
+class TestAuthError:
+    """Test that auth errors are raised correctly."""
+
+    async def test_tv_without_auth_raises_auth_error(self):
+        vizio = VizioAsync("pyvizio", TV_IP_PORT, "TV", "", "tv")
+        with pytest.raises(VizioAuthError, match="Empty auth token"):
+            await vizio.get_power_state()
+
+    async def test_speaker_without_auth_does_not_raise(self):
+        """Speakers don't require auth, so no error should be raised."""
+        from tests.conftest import SPEAKER_IP_PORT, speaker_url
+
+        vizio = VizioAsync("pyvizio", SPEAKER_IP_PORT, "Speaker", "", "speaker")
+        with aioresponses() as m:
+            m.get(speaker_url("POWER_MODE"), payload=make_power_response(1))
+            result = await vizio.get_power_state()
+        assert result is True
+
+
+class TestDeviceTypeError:
+    """Test that invalid device types raise VizioError."""
+
+    def test_invalid_device_type_raises(self):
+        with pytest.raises(VizioError, match="Invalid device type"):
+            VizioAsync("pyvizio", TV_IP_PORT, "TV", AUTH_TOKEN, "invalid")
+
+
+class TestInvokeApiPreservesNoneReturn:
+    """Test that typed exceptions from validate_response are caught by invoke_api,
+    preserving the existing None-return behavior."""
+
+    async def test_connection_error_returns_none(self):
+        vizio = VizioAsync("pyvizio", TV_IP_PORT, "TV", AUTH_TOKEN, "tv")
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), status=500)
+            result = await vizio.get_power_state(log_api_exception=False)
+        assert result is None
+
+    async def test_invalid_param_returns_none(self):
+        vizio = VizioAsync("pyvizio", TV_IP_PORT, "TV", AUTH_TOKEN, "tv")
+        with aioresponses() as m:
+            m.get(tv_url("POWER_MODE"), payload=make_error_response())
+            result = await vizio.get_power_state(log_api_exception=False)
+        assert result is None


### PR DESCRIPTION
## Summary
- Add `pyvizio/errors.py` with `VizioError` base and typed subclasses: `VizioConnectionError`, `VizioAuthError`, `VizioInvalidParameterError`, `VizioResponseError`
- Replace all bare `Exception` raises in `_protocol.py` and `__init__.py` with typed exceptions
- Use `VizioInvalidParameterError` for parameter validation (invalid device_type, port conflict)
- Re-export error types from `__init__.py` for public API

## Dependencies
- Depends on #188 (device-config)

## Test plan
- [x] `uv run pytest tests/` — 219 tests pass (16 new error tests)
- [x] `uv run --extra dev mypy --warn-unused-ignores pyvizio/` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)